### PR TITLE
Replaced spaces in links with %20

### DIFF
--- a/index.html
+++ b/index.html
@@ -74,16 +74,16 @@
                             <b>Written Work</b><br>
                             <a href="https://drive.google.com/file/d/0B0iSCqNs5-x9TmY2ZFFwZE43NEE/view?usp=sharing">&#128274; Current Thesis version (Draft)</a><br>
                             <a href="TXT/Blake_Transfer_Report.pdf">24 Month Research Report (Transfer)</a><br>
-                            <a href="TXT/Jack Blake - 12 Month Research Report.pdf">12 Month Research Report</a><br>
-                            <a href="TXT/Jack Blake - Preconditioning of Iterative Methods for the Transport Equation.pdf">MSc Dissertation</a><br>
+                            <a href="TXT/Jack%20Blake%20-%2012%20Month%20Research%20Report.pdf">12 Month Research Report</a><br>
+                            <a href="TXT/Jack%20Blake%20-%20Preconditioning%20of%20Iterative%20Methods%20for%20the%20Transport%20Equation.pdf">MSc Dissertation</a><br>
                             <a href="http://www.sciencedirect.com/science/article/pii/S0375960111011194">Target-Oriented Chaos Control</a><br>
 
                             <br><b>Talks</b><br>
                             <a href="TXT/Blake_strathclyde_2015.pdf">Domain Decomposition Methods for the Neutron Transport Equation, 23/06/15</a><br>
                             <a href="TXT/1411_Iteratively_solving_the_neutron_transport_equation.pdf">Iteratively Solving the Neutron Transport Equation, 28/11/14</a><br>
                             <a href="140410_Blake_Colorado.pdf">A Domain Decomposition Approach to Diffusion Synthetic Acceleration (renamed), 11/04/14</a><br>
-                            <a href="TXT/Jack Blake - Presentation - The Idea Behind Krylov Methods.pdf">The Idea Behind Krylov Methods, 02/05/12</a><br>
-                            <a href="TXT/Jack Blake - Presentation - Preconditioning of Iterative Methods for the Transport Equation.pdf">Preconditioning of Iterative Methods for the Transport Equation, 20/10/11</a><br>
+                            <a href="TXT/Jack%20Blake%20-%20Presentation%20-%20The%20Idea%20Behind%20Krylov%20Methods.pdf">The Idea Behind Krylov Methods, 02/05/12</a><br>
+                            <a href="TXT/Jack%20Blake%20-%20Presentation%20-%20Preconditioning%20of%20Iterative%20Methods%20for%20the%20Transport%20Equation.pdf">Preconditioning of Iterative Methods for the Transport Equation, 20/10/11</a><br>
                         </h6>
                 </article>
 


### PR DESCRIPTION
This is to conform with w3 standards and pass the markup validator
at https://validator.w3.org/ .
